### PR TITLE
File on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 2.89.1-9 (Not Released yet)
+* Support of fileOnMaster for credentials type sshkey [#70](https://github.com/odavid/my-bloody-jenkins/issues/70)
+
 ### 2.89.1-8
 * Added Perforce Credentials:
     * p4-pass - p4 password

--- a/tests/groovy/CredsConfigTest.groovy
+++ b/tests/groovy/CredsConfigTest.groovy
@@ -56,11 +56,22 @@ ssh-key-as-base64:
   username: user
   passphrase: password1234
   base64: ${base64Text}
+ssh-key-fileOnMaster:
+  type: sshkey
+  description: git-ssh-key
+  username: user
+  passphrase: password1234
+  fileOnMaster: '/root/.ssh/id_rsa'
 cert-cred:
   type: cert
   description: cert description
   password: secret
   base64: ${base64Text}
+cert-cred-fileOnMaster:
+  type: cert
+  description: cert description
+  password: secret
+  fileOnMaster: '/root/xxx.crt'
 p4-pass-cred:
   type: p4-pass
   description: p4 pass description
@@ -120,11 +131,23 @@ p4-ticket-cred:
         assert it.passphrase.toString() == "password1234"
         assert it.privateKey == text
     }
+    assertCred("ssh-key-fileOnMaster", com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey){
+        assert it.description == "git-ssh-key"
+        assert it.username == "user"
+        assert it.passphrase.toString() == "password1234"
+        assert it.privateKeySource.privateKeyFile == '/root/.ssh/id_rsa'
+    }
     assertCred("cert-cred", com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl){
         assert it.description == "cert description"
         assert it.password.toString() == "secret"
         assert it.keyStoreSource instanceof com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl.UploadedKeyStoreSource
         assert it.keyStoreSource.keyStoreBytes
+    }
+    assertCred("cert-cred-fileOnMaster", com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl){
+        assert it.description == "cert description"
+        assert it.password.toString() == "secret"
+        assert it.keyStoreSource instanceof com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl.FileOnMasterKeyStoreSource
+        assert it.keyStoreSource.keyStoreFile == '/root/xxx.crt'
     }
     assertCred("p4-pass-cred", org.jenkinsci.plugins.p4.credentials.P4PasswordImpl){
         assert it.description == "p4 pass description"


### PR DESCRIPTION
Fixes #70 - support fileOnMaster attribute for both sshkey and cert credentials
```yaml
credentials:
  cert-cred-fileOnMaster:
    type: cert
    description: cert description
    password: secret
    fileOnMaster: '/root/xxx.crt'

  ssh-key-fileOnMaster:
    type: sshkey
    description: git-ssh-key
    username: user
    passphrase: password1234
    fileOnMaster: '/root/.ssh/id_rsa'
```