### PR TITLE
Added markupFormatter securityOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,19 @@ security:
       - JNLP2
       - JNLP3
       - JNLP4
+    
+    ## MarkupFormatter plainText
+    markupFormatter: plainText
+
+    ## MarkupFormatter safeHtml
+    markupFormatter: safeHtml
+
+    ## MarkupFormatter safeHtml with disableSyntaxHighlighting
+    markupFormatter:
+      rawHtmlMarkupFormatter:
+        disableSyntaxHighlighting: true
+
+
 ```
 
 ### Tools Section

--- a/config-handlers/SecurityConfig.groovy
+++ b/config-handlers/SecurityConfig.groovy
@@ -115,6 +115,7 @@ def setupSecurityOptions(config){
     config.disableRememberMe = asBoolean(config.disableRememberMe)
     config.sshdEnabled = asBoolean(config.sshdEnabled)
     config.jnlpProtocols = config.jnlpProtocols != null ? config.jnlpProtocols : ['JNLP4']
+    config.markupFormatter = config.markupFormatter != null ? config.markupFormatter : 'plainText'
 
     config.with{
         if(preventCSRF){
@@ -137,6 +138,23 @@ def setupSecurityOptions(config){
         }else{
             org.jenkinsci.main.modules.sshd.SSHD.get().port = -1
         }
+
+        def mupFormatter
+        if((markupFormatter instanceof Map && markupFormatter.size() == 1)){
+            def key = markupFormatter.keySet()[0]
+            if(key.toLowerCase() == 'RawHtmlMarkupFormatter'.toLowerCase()){
+                def disableSyntaxHighlighting = asBoolean(markupFormatter[(key)]?.disableSyntaxHighlighting, false)
+                mupFormatter = new hudson.markup.RawHtmlMarkupFormatter(disableSyntaxHighlighting)
+            }
+        }else if(markupFormatter == 'plainText'){
+            mupFormatter = new hudson.markup.EscapedMarkupFormatter()
+        }else if(markupFormatter == 'safeHtml'){
+            mupFormatter = new hudson.markup.RawHtmlMarkupFormatter(false)
+        }
+        if(mupFormatter){
+            jenkins.model.Jenkins.instance.markupFormatter = mupFormatter
+        }
+
         jenkins.model.Jenkins.instance.save()
     }
 }

--- a/tests/groovy/config-handlers/SecurityConfigTest.groovy
+++ b/tests/groovy/config-handlers/SecurityConfigTest.groovy
@@ -146,8 +146,53 @@ adminPassword: admin
  }
 
 
+def testPlainTextMarkupFormatter(){
+    def config = new Yaml().load("""
+markupFormatter: plainText
+"""
+    )
+    configHandler.setupSecurityOptions(config)
+    assert jenkins.model.Jenkins.instance.markupFormatter instanceof hudson.markup.EscapedMarkupFormatter
+}
+
+def testSafeHtmlMarkupFormatter(){
+    def config = new Yaml().load("""
+markupFormatter: safeHtml
+"""
+    )
+    configHandler.setupSecurityOptions(config)
+    assert jenkins.model.Jenkins.instance.markupFormatter instanceof hudson.markup.RawHtmlMarkupFormatter
+}
+
+def testRawHtmlMarkupFormatter(){
+    def config = new Yaml().load("""
+markupFormatter:
+  rawHtmlMarkupFormatter:
+"""
+    )
+    configHandler.setupSecurityOptions(config)
+    assert jenkins.model.Jenkins.instance.markupFormatter instanceof hudson.markup.RawHtmlMarkupFormatter
+    assert !jenkins.model.Jenkins.instance.markupFormatter.disableSyntaxHighlighting
+}
+
+def testRawHtmlMarkupFormatterWithDisableSyntaxHighlighting(){
+    def config = new Yaml().load("""
+markupFormatter:
+  rawHtmlMarkupFormatter:
+    disableSyntaxHighlighting: true
+"""
+    )
+    configHandler.setupSecurityOptions(config)
+    assert jenkins.model.Jenkins.instance.markupFormatter instanceof hudson.markup.RawHtmlMarkupFormatter
+    assert jenkins.model.Jenkins.instance.markupFormatter.disableSyntaxHighlighting
+}
+
 testLdap()
 testActiveDirectory()
 testAuthorizationStrategy()
 testSecurityOptions()
 testJenkinsDatabase()
+testPlainTextMarkupFormatter()
+testSafeHtmlMarkupFormatter()
+testRawHtmlMarkupFormatter()
+testRawHtmlMarkupFormatterWithDisableSyntaxHighlighting()


### PR DESCRIPTION
Ability to configure `markupFormatter` within found in Jenkins Security page.
Options are:

`plainText` - default
```yaml
security:
  securityOptions:
    markupFormatter: plainText
```
`safeHtml` - using https://plugins.jenkins.io/antisamy-markup-formatter
```yaml
security:
  securityOptions:
    markupFormatter: safeHtml
```

`safeHtml + disableSyntaxHighlighting` - using https://plugins.jenkins.io/antisamy-markup-formatter
```yaml
security:
  securityOptions:
    markupFormatter:
      rawHtmlMarkupFormatter:
        disableSyntaxHighlighting: true
```
