### PR TITLE
Jira steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Updated plugins
     * [ssh-slaves:1.28](https://plugins.jenkins.io/ssh-slaves)
     * [kubernetes:1.12.4](https://plugins.jenkins.io/kubernetes)
+    * Added [jira-steps:1.4.3](https://plugins.jenkins.io/jira-steps)
     
 ## 2.121.3-69
 * [LTS-2.121.3](https://jenkins.io/changelog-stable/)

--- a/config-handlers/JiraStepsConfig.groovy
+++ b/config-handlers/JiraStepsConfig.groovy
@@ -1,0 +1,35 @@
+def asInt(value, defaultValue=0){
+    return value ? value.toInteger() : defaultValue
+}
+def asBoolean(value, defaultValue=false){
+    return value != null ? value.toBoolean() : defaultValue
+}
+
+def setup(config) {
+    config = config ?: [:]
+    def desc = org.thoughtslive.jenkins.plugins.jira.Config.DESCRIPTOR
+    def sites = config.sites?.collect{ siteConfig ->
+        siteConfig.with{
+            def site = new org.thoughtslive.jenkins.plugins.jira.Site(
+                    name ?: url,
+                    url ? new URL(url) : null,
+                    loginType ?: 'BASIC',
+                    asInt(timeout, 0)
+                )
+            site.userName = userName
+            site.password = password
+            site.secret = secret
+            site.readTimeout = asInt(readTimeout, 0)
+            site.token = token
+            return site
+        }
+    }
+    if(sites){
+        def formData = [:] as net.sf.json.JSONObject
+        def req = [
+            bindJSONToList: {clz, obj -> return sites}
+        ] as org.kohsuke.stapler.StaplerRequest
+        desc.configure(req, formData)
+    }
+}
+return this

--- a/init-scripts/JenkinsConfigLoader.groovy
+++ b/init-scripts/JenkinsConfigLoader.groovy
@@ -89,7 +89,7 @@ if(!new File(configFileName).exists()) {
     def jenkinsConfig = loadYamlConfig(configFileName)
     if(!jenkinsConfig){
         println "jenkinsConfig is empty, skipping"
-        return 
+        return
     }
     // TODO: admin user should be global. Make it more generic....
     jenkinsConfig.security?.adminUser = adminUser
@@ -108,6 +108,7 @@ if(!new File(configFileName).exists()) {
     handleConfig('Tools', jenkinsConfig.tools)
     handleConfig('SonarQubeServers', jenkinsConfig.sonar_qube_servers)
     handleConfig('Jira', jenkinsConfig.jira)
+    handleConfig('JiraSteps', jenkinsConfig.jiraSteps)
     handleConfig('Checkmarx', jenkinsConfig.checkmarx)
     handleConfig('Gitlab', jenkinsConfig.gitlab)
     handleConfig('PipelineLibraries', jenkinsConfig.pipeline_libraries)

--- a/plugins.txt
+++ b/plugins.txt
@@ -86,6 +86,7 @@ javadoc:1.4
 jdk-tool:1.1
 jenkins-design-language:1.8.2
 jira:3.0.1
+jira-steps:1.4.3
 job-dsl:1.70
 jquery:1.12.4-0
 jquery-detached:1.2.1

--- a/tests/config-handlers-tests.bats
+++ b/tests/config-handlers-tests.bats
@@ -55,6 +55,10 @@ function groovy_test(){
     groovy_test
 }
 
+@test "JiraStepsConfig" {
+    groovy_test
+}
+
 @test "NotifiersConfig" {
     groovy_test
 }
@@ -80,7 +84,7 @@ function groovy_test(){
 }
 
 @test "<<< teardown config-handlers tests env" {
-    docker_compose_down $COMPOSE_FILE 
+    docker_compose_down $COMPOSE_FILE
     destroy_docker_network
     rm -rf $TESTS_HOST_CONF_DIR
 }

--- a/tests/groovy/config-handlers/JiraStepsConfigTest.groovy
+++ b/tests/groovy/config-handlers/JiraStepsConfigTest.groovy
@@ -1,0 +1,34 @@
+import org.yaml.snakeyaml.Yaml
+
+handler = 'JiraSteps'
+configHandler = evaluate(new File("/usr/share/jenkins/config-handlers/${handler}Config.groovy"))
+
+def testJiraSteps(){
+    def config = new Yaml().load("""
+sites:
+  - name: JIRA
+    url: https://jira.domain.com
+    loginType: OAUTH
+    secret: secret
+    token: token
+    timeout: 10
+    readTimeout: 20
+    userName: jira
+    password: jira
+
+""")
+
+    configHandler.setup(config)
+    def desc = org.thoughtslive.jenkins.plugins.jira.Config.DESCRIPTOR
+    def site = desc.sites[0]
+    assert site.name == ('JIRA')
+    assert site.url == (new URL('https://jira.domain.com'))
+    assert site.loginType == 'OAUTH'
+    assert site.secret.toString() == 'secret'
+    assert site.token.toString() == 'token'
+    assert site.timeout == 10
+    assert site.readTimeout == 20
+    assert site.userName == 'jira'
+    assert site.password.toString() == 'jira'
+}
+testJiraSteps()


### PR DESCRIPTION
Added support for [jira-steps plugin](https://plugins.jenkins.io/jira-steps)

Config:

```yaml
jiraSteps:
  sites:
  - name: JIRA
    url: https://jira.domain.com
    loginType: OAUTH # Default BASIC
    secret: secret
    token: token
    timeout: 10
    readTimeout: 20
    userName: jira
    password: jira
 ```