### PR TITLE
Added dynamic SCMSource for pipeline library retriever

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,8 @@ notifiers:
 Responsible for setting up [Global Pipeline Libraries](https://wiki.jenkins.io/display/JENKINS/Pipeline+Shared+Groovy+Libraries+Plugin)
 
 Configuration is composed of dicts where each top level key is the name of the library and its value contains the library configuration (source, default version)
+In case the SCM Source is not git, you can use dynamic configuration based on the SCMSource class.
+
 ```yaml
 pipeline_libraries:
   my-library: # the library name
@@ -549,6 +551,15 @@ pipeline_libraries:
     implicit: false # Default false - if true the library will be available within all pipeline jobs with declaring it with @Library
     allowVersionOverride: true # Default true, better to leave it as is
     includeInChangesets: true # see https://issues.jenkins-ci.org/browse/JENKINS-41497
+
+  library-from-p4:
+    ## retriever.scm.$class can be symbol or full class name
+    ## Other properties of retriever.scm should match the class properties.
+    retriever:
+      scm:
+        $class: org.jenkinsci.plugins.p4.scm.GlobalLibraryScmSource
+        path: //xxx/yyy
+        credential: p4-creds
 
   my-other-lib:
     source:

--- a/config-handlers/PipelineLibrariesConfig.groovy
+++ b/config-handlers/PipelineLibrariesConfig.groovy
@@ -1,3 +1,6 @@
+import org.jenkinsci.plugins.structs.describable.DescribableModel
+import jenkins.model.Jenkins
+
 def asInt(value, defaultValue=0){
     return value ? value.toInteger() : defaultValue
 }
@@ -5,33 +8,78 @@ def asBoolean(value, defaultValue=false){
     return value != null ? value.toBoolean() : defaultValue
 }
 
+def tryCreateDynamicSCMSource(libraryName, config){
+    def type = config['$class']
+    def klass
+    if(type.contains('.')){
+        try{
+            klass = Class.forName(type)
+        }catch(e){
+            println "Could not find SCMSource class for symbol: $type, skipping pipeline lib: $libraryName"
+            return null
+        }
+    }else{
+        def matchedDescriptor = Jenkins.get().getDescriptorList(jenkins.scm.api.SCMSource)
+            .find{ it.klass.toJavaClass().simpleName.toLowerCase().startsWith(type.toLowerCase()) }
+        if(!matchedDescriptor){
+            println "Could not find SCMSource class for symbol: $type, skipping pipeline lib: $libraryName"
+            return null
+        }
+        klass = matchedDescriptor.klass.toJavaClass()
+    }
+    DescribableModel model
+    try{
+        model = DescribableModel.of(klass)
+    }catch(e){
+        println "Could not find DescribableModel for: $klass, skipping pipeline lib: $libraryName"
+        return null
+    }
+    try{
+        return model.instantiate(config)
+    }catch(e){
+        println "Could not instantiate DescribableModel for: $klass, skipping pipeline lib: $libraryName"
+        e.printStackTrace(out)
+        return null
+    }
+}
+
+
+
 def libraryConfig(config){
     config.with{
-        def libraryConfiguration = new org.jenkinsci.plugins.workflow.libs.LibraryConfiguration(
-            name, 
-            new org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever(
-                new jenkins.plugins.git.GitSCMSource(
-                    "git-scm-${name}",
-                    source?.remote,
-                    source?.credentialsId,
-                    source?.includes ?: '*',  //includes
-                    source?.excludes ?: '',   //excludes
-                    asBoolean(source.ignoreOnPushNotifications) //ignoreOnPushNotifications
-                )
+        def scmConfig = retriever?.scm
+        def scm
+        if(!scmConfig){
+            scm = new jenkins.plugins.git.GitSCMSource(
+                "git-scm-${name}",
+                source?.remote,
+                source?.credentialsId,
+                source?.includes ?: '*',  //includes
+                source?.excludes ?: '',   //excludes
+                asBoolean(source.ignoreOnPushNotifications) //ignoreOnPushNotifications
             )
-        )
-        libraryConfiguration.defaultVersion = defaultVersion
-        libraryConfiguration.implicit = asBoolean(implicit)
-        libraryConfiguration.allowVersionOverride = asBoolean(allowVersionOverride, true)
-        libraryConfiguration.includeInChangesets = asBoolean(includeInChangesets, true)
-        return libraryConfiguration
+        }else{
+            scm = tryCreateDynamicSCMSource(name, scmConfig)
+        }
+        if(scm){
+            def libraryConfiguration = new org.jenkinsci.plugins.workflow.libs.LibraryConfiguration(
+                name,
+                new org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever(scm)
+            )
+            libraryConfiguration.defaultVersion = defaultVersion
+            libraryConfiguration.implicit = asBoolean(implicit)
+            libraryConfiguration.allowVersionOverride = asBoolean(allowVersionOverride, true)
+            libraryConfiguration.includeInChangesets = asBoolean(includeInChangesets, true)
+            return libraryConfiguration
+        }
+        return null
     }
 }
 
 def setup(config){
     config = config ?: [:]
-    org.jenkinsci.plugins.workflow.libs.GlobalLibraries.get().libraries = config.collect{ k,v -> 
+    org.jenkinsci.plugins.workflow.libs.GlobalLibraries.get().libraries = config.collect{ k,v ->
         libraryConfig([name: k] + v)
-    }
+    }.grep()
 }
 return this

--- a/tests/groovy/config-handlers/PipelineLibrariesConfigTest.groovy
+++ b/tests/groovy/config-handlers/PipelineLibrariesConfigTest.groovy
@@ -21,6 +21,15 @@ my-lib-with-defaults:
   source:
     remote: git@github.com:odavid/my-bloody-jenkins.git
     credentialsId: my-git-key
+dynamic-scm-source:
+  defaultVersion: p4-version
+  implicit: true
+  retriever:
+    scm:
+      \$class: org.jenkinsci.plugins.p4.scm.GlobalLibraryScmSource
+      path: //xxx/yyy
+      credential: p4-creds
+      charset:
 """)
 
     configHandler.setup(config)
@@ -47,6 +56,13 @@ my-lib-with-defaults:
     assert myLib.retriever.scm.includes == '*'
     assert myLib.retriever.scm.excludes == ''
     assert !myLib.retriever.scm.ignoreOnPushNotifications
+
+    myLib = org.jenkinsci.plugins.workflow.libs.GlobalLibraries.get().libraries.find{ it.name == 'dynamic-scm-source'}
+    assert myLib.defaultVersion == 'p4-version'
+    assert myLib.implicit
+    assert (myLib.retriever.scm instanceof org.jenkinsci.plugins.p4.scm.GlobalLibraryScmSource)
+    assert myLib.retriever.scm.credential == 'p4-creds'
+    assert myLib.retriever.scm.path == '//xxx/yyy'
 }
 
 testLibraries()


### PR DESCRIPTION
Support pipeline libraries scm other than git using
```yaml
pipeline_libraries:
  my-non-git-lib:
    retriever:
      scm:
        $class: <SCMSource Class name>
        # SCMSource Attributes
        ...
```