### PR TITLE
fix Docker example startup script 

### DIFF
--- a/examples/docker/jenkins_server.sh
+++ b/examples/docker/jenkins_server.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-. ./set_secrets.sh
-
 action='restart'
 if [[ $# > 0 ]]; then
    action=$1


### PR DESCRIPTION
remove the wrong call to secrets.sh script that not exists