### PR TITLE
Add google-login plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -78,6 +78,7 @@ github-api:1.95
 github-branch-source:2.4.1
 github:1.29.3
 gitlab-plugin:1.5.11
+google-login:1.4
 gradle:1.29
 groovy-postbuild:2.4.3
 handlebars:1.1.1


### PR DESCRIPTION
For authenticating with Google domain accounts (a new 'Security Realm' option 'Login with Google' in the 'Configure Global Security' form), this plugin is required.
For now, this setting will be done manually, but later on, a new configurator will be most welcome.