### PR TITLE
Added configuration_as_code config handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,13 @@ Supported URLs:
 
 * `JENKINS_ENV_ADMIN_ADDRESS` - Define the Jenkins admin email address
 
-* `JENKINS_ENV_PLUGINS` - Ability to define comma separated list of additional plugins to install before starting up. See [plugin-version-format](https://github.com/jenkinsci/docker#plugin-version-format). This is option is not recommended, but sometimes it is useful to run the container without creating an inherited image.
+* `JENKINS_ENV_PLUGINS` - Ability to define comma separated list of additional plugins to install before starting up. See [plugin-version-format](https://github.com/jenkinsci/docker#plugin-version-format).
+> This is option is not recommended, but sometimes it is useful to run the container without creating an inherited image.
 
 * `JENKINS_ENV_QUIET_STARTUP_PERIOD` - Time in seconds. If speficied, jenkins will start in quiet mode and disable all running jobs. Useful for major upgrade.
 
-* `JENKINS_ENV_CONFIG_MODE` - If set to `jcasc`, then [Configuration as Code Plugin](https://github.com/jenkinsci/configuration-as-code-plugin) will be used instead of [Built-in Configuration Handlers](#configuration-reference). By using this mode, see [JCasC Demo](./demo/jcasc-plugin)
+* `JENKINS_ENV_CONFIG_MODE` - If set to `jcasc`, then [Configuration as Code Plugin](https://github.com/jenkinsci/configuration-as-code-plugin) will be used instead of [Built-in Configuration Handlers](#configuration-reference). See [JCasC Demo](./demo/jcasc-plugin).
+> This option will disable all configuration handlers used by the image! If you still want to use builtin configuration handlers, together with dynamic JCasC snippets, please see [Configuration as Code Section](#configuration-as-code-section).
 
 ## Configuration Reference
 The configuration is divided into main configuration sections. Each section is responsible for a specific aspect of jenkins configuration.
@@ -361,6 +363,26 @@ security:
       rawHtmlMarkupFormatter:
         disableSyntaxHighlighting: true
 
+
+```
+
+### Configuration as Code Section
+The `configuration_as_code` yaml section enables *"Mixed-Mode"* configuration style. It enables embedding [configuration as code snippets](https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos) within the configuration yaml. This enables out of the box support for plugins configuration that do not have a builtin configuration handler.
+
+```yaml
+configuration_as_code:
+  unclassified:
+  ## https://github.com/jenkinsci/configuration-as-code-plugin/blob/1f79326e902fe721a3a05077a7e46f98569804ff/demos/simple-theme-plugin/README.md
+    simple-theme-plugin:
+      elements:
+      - cssUrl:
+          url: "https://example.bogus/test.css"
+      - cssText:
+          text: ".testcss { color: red }"
+      - jsUrl:
+          url: "https://example.bogus/test.js"
+      - faviconUrl:
+          url: "https://vignette.wikia.nocookie.net/deadpool/images/6/64/Favicon.ico"
 
 ```
 

--- a/config-handlers/ConfigurationAsCodeConfig.groovy
+++ b/config-handlers/ConfigurationAsCodeConfig.groovy
@@ -1,0 +1,21 @@
+import org.yaml.snakeyaml.Yaml
+import io.jenkins.plugins.casc.yaml.YamlSource
+import io.jenkins.plugins.casc.ConfigurationAsCode
+
+def asInt(value, defaultValue=0){
+    return value ? value.toInteger() : defaultValue
+}
+def asBoolean(value, defaultValue=false){
+    return value != null ? value.toBoolean() : defaultValue
+}
+
+def setup(config) {
+    if(config){
+        def yamlString = new Yaml().dump(config)
+        ByteArrayInputStream bais = new ByteArrayInputStream(yamlString.getBytes('UTF8'))
+        def yamlSource = YamlSource.of(bais)
+        ConfigurationAsCode.get().configureWith(yamlSource)
+    }
+
+}
+return this

--- a/init-scripts/JenkinsConfigLoader.groovy
+++ b/init-scripts/JenkinsConfigLoader.groovy
@@ -135,6 +135,7 @@ if(!new File(configFileName).exists()) {
     handleConfig('PipelineLibraries', jenkinsConfig.pipeline_libraries)
     handleConfig('SeedJobs', jenkinsConfig.seed_jobs)
     handleConfig('JobDSLScripts', jenkinsConfig.job_dsl_scripts)
+    handleConfig('ConfigurationAsCode', jenkinsConfig.configuration_as_code)
 
     handleCustomConfig(jenkinsConfig.customConfig)
 }

--- a/tests/config-handlers-tests.bats
+++ b/tests/config-handlers-tests.bats
@@ -19,6 +19,10 @@ function groovy_test(){
     groovy_test
 }
 
+@test "ConfigurationAsCodeConfig" {
+    groovy_test
+}
+
 @test "RemoveMasterEnvVarsConfig" {
     groovy_test
 }

--- a/tests/groovy/config-handlers/ConfigurationAsCodeConfigTest.groovy
+++ b/tests/groovy/config-handlers/ConfigurationAsCodeConfigTest.groovy
@@ -1,0 +1,28 @@
+import org.yaml.snakeyaml.Yaml
+
+handler = 'ConfigurationAsCode'
+configHandler = evaluate(new File("/usr/share/jenkins/config-handlers/${handler}Config.groovy"))
+
+def testJCasC(){
+ 	def config = new Yaml().load("""
+unclassified:
+  ## https://github.com/jenkinsci/configuration-as-code-plugin/blob/1f79326e902fe721a3a05077a7e46f98569804ff/demos/simple-theme-plugin/README.md
+  simple-theme-plugin:
+    elements:
+      - cssUrl:
+          url: "https://example.bogus/test.css"
+      - cssText:
+          text: ".testcss { color: red }"
+      - jsUrl:
+          url: "https://example.bogus/test.js"
+      - faviconUrl:
+          url: "https://vignette.wikia.nocookie.net/deadpool/images/6/64/Favicon.ico"
+""")
+    configHandler.setup(config)
+    def simpleTheme = jenkins.model.Jenkins.instance.getExtensionList(org.codefirst.SimpleThemeDecorator)[0]
+    assert simpleTheme.elements[0].url == 'https://example.bogus/test.css'
+    assert simpleTheme.elements[1].text == '.testcss { color: red }'
+    assert simpleTheme.elements[2].url == 'https://example.bogus/test.js'
+}
+
+testJCasC()


### PR DESCRIPTION
Embedding JCasC snippets within config.yaml.
Enables unclassified plugins configuration.


