### PR TITLE
Enable to put a tag in the 'branch' setting of a seed-job'

### DIFF
--- a/config-handlers/SeedJobsConfig.groovy
+++ b/config-handlers/SeedJobsConfig.groovy
@@ -52,7 +52,7 @@ def seedJobConfig(config){
                 source?.remote, 
                 source?.credentialsId
             ), 
-            source?.branch ? [new hudson.plugins.git.BranchSpec("*/${source?.branch}")] : [], 
+            source?.branch ? [new hudson.plugins.git.BranchSpec("${source?.branch}")] : [],
             null, 
             null, 
             null, 

--- a/tests/groovy/config-handlers/SeedJobsConfigTest.groovy
+++ b/tests/groovy/config-handlers/SeedJobsConfigTest.groovy
@@ -74,7 +74,7 @@ my-seed-job:
     assert job instanceof org.jenkinsci.plugins.workflow.job.WorkflowJob
     assert job.definition.scm.userRemoteConfigs[0].url == 'git@github.com:odavid/my-bloody-jenkins.git'
     assert job.definition.scm.userRemoteConfigs[0].credentialsId == 'my-git-key'
-    assert job.definition.scm.branches[0].name == '*/my-test-branch'
+    assert job.definition.scm.branches[0].name == 'my-test-branch'
     assert job.definition.scriptPath == 'src/groovy/Jenkinsfile-config'
 
     def paramsDef = job.getProperty(hudson.model.ParametersDefinitionProperty).parameterDefinitions


### PR DESCRIPTION
With this change, you can put a tag as the branch parameter