### PR TITLE
Support mode = NORMAL or EXCLUSIVE in docker templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,9 @@ clouds:
         # has privileges to that socket within the entrypoint
         volumes:
           - '/var/run/docker.sock:/var/run/docker.sock'
+        # EXCLUSIVE (Default) - Only build jobs with label expressions matching this node
+        # NORAL = Use this node as much as possible
+        nodeUsageMode: EXCLUSIVE
         # Environment variables to pass to the slave container
         environment:
           XXX: xxx
@@ -770,6 +773,7 @@ clouds:
         yaml: |-
           spec: xxx
           metadata: yyy
+
 
 ```
 
@@ -803,6 +807,9 @@ clouds:
         # Environment variables to pass to the slave container
         environment:
           XXX: xxx
+        # EXCLUSIVE (Default) - Only build jobs with label expressions matching this node
+        # NORAL = Use this node as much as possible
+        mode: EXCLUSIVE
 ```
 
 

--- a/config-handlers/CloudsConfig.groovy
+++ b/config-handlers/CloudsConfig.groovy
@@ -129,7 +129,7 @@ def dockerCloud(config){
                     ]
                 }
 
-                dockerTemplate.mode = Node.Mode.EXCLUSIVE
+                dockerTemplate.mode = temp.mode ? Node.Mode.valueOf(temp.mode) : Node.Mode.EXCLUSIVE
                 dockerTemplate.connector.user = temp.jnlpUser ?: config.jnlpUser ?: ''
                 if(jenkinsUrl){
                     dockerTemplate.connector.jenkinsUrl = jenkinsUrl
@@ -246,7 +246,7 @@ def kubernetesCloud(config){
                 podTemplate.containers << containerTemplate
                 podTemplate.namespace = temp.namespace
                 podTemplate.label = temp.labels?.join(' ')
-                podTemplate.nodeUsageMode = Node.Mode.EXCLUSIVE
+                podTemplate.nodeUsageMode = temp.nodeUsageMode ? Node.Mode.valueOf(temp.nodeUsageMode) : Node.Mode.EXCLUSIVE
                 podTemplate.inheritFrom = temp.inheritFrom
                 podTemplate.nodeSelector = temp.nodeSelector
                 podTemplate.serviceAccount = temp.serviceAccount


### PR DESCRIPTION
Added support for [hudson.model.Node.Mode](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Node.java#L578)

When defining `docker.template[*].mode` or `kubernetes.template[*].nodeUsageMode`
* `EXCLUSIVE` (Default) - Only build jobs with label expressions matching this node
* `NORAL` - Use this node as much as possible
