### PR TITLE
Support file credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,9 @@ Responsible for:
 * The following types are supported:
     * type: text - [simple secret](https://wiki.jenkins.io/display/JENKINS/Plain+Credentials+Plugin). Mandatory attributes:
         * text - the text to encrypt
+    * type: file - [file secret](https://wiki.jenkins.io/display/JENKINS/Plain+Credentials+Plugin). Mandatory attributes:
+        * fileName - the fileName
+        * secretBytes - a base64 encoded string of the file contents.
     * type: aws - an [aws secret](https://wiki.jenkins.io/display/JENKINS/CloudBees+AWS+Credentials+Plugin). Mandatory attributes:
         * access_key - AWS access key
         * secret_access_key - AWS secret access key
@@ -513,8 +516,14 @@ The logic for dealing with unknown types is as follows:
 credentials:
   slack:
     type: text
-    description: The slace secret token
+    description: The slak secret token
     text: slack-secret-token
+  a-secret-file:
+    type: file
+    description: An encrypted file with contents
+    # Always base64
+    secretBytes: VGhpcyBpcyBhIHBsYWluIGNvbnRlbnQK # -> 'This is a plain content' | base64
+    fileName: my-secret-file
   hipchat:
     type: text
     text: hipchat-token

--- a/config-handlers/CredsConfig.groovy
+++ b/config-handlers/CredsConfig.groovy
@@ -113,6 +113,19 @@ def textCred(config){
     }
 }
 
+def fileCred(config){
+    config.with{
+        return new org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl(
+            CredentialsScope.GLOBAL,
+            id,
+            description,
+            null,
+            fileName,
+            com.cloudbees.plugins.credentials.SecretBytes.fromString(secretBytes)
+        )
+    }
+}
+
 def certCred(config){
     config.with{
         def keyStoreSource = null
@@ -208,6 +221,8 @@ def setup(config){
                 return userPassCred(credConfig)
             case 'text':
                 return textCred(credConfig)
+            case 'file':
+                return fileCred(credConfig)
             case 'sshkey':
                 return sshKeyCred(credConfig)
             case 'cert':

--- a/tests/groovy/config-handlers/CredsConfigTest.groovy
+++ b/tests/groovy/config-handlers/CredsConfigTest.groovy
@@ -28,6 +28,11 @@ text-cred:
   type: text
   description: The slace secret token
   text: slack-secret-token
+file-cred:
+  type: file
+  description: This is a file
+  secretBytes: QUJDREVG
+  fileName: myFile
 aws-cred:
   type: aws
   access_key: xxxx
@@ -121,6 +126,11 @@ dynamic-p4-ticket-cred:
     assertCred("text-cred", org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl){
         assert it.description == "The slace secret token"
         assert it.secret.toString() == "slack-secret-token"
+    }
+    assertCred("file-cred", org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl){
+        assert it.description == "This is a file"
+        assert it.secretBytes.plainData.encodeBase64().toString() == "QUJDREVG"
+        assert it.fileName == "myFile"
     }
     assertCred("aws-cred", com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl){
         assert it.description == "aws description"


### PR DESCRIPTION
Support [file credentials](https://github.com/jenkinsci/plain-credentials-plugin/blob/master/src/main/java/org/jenkinsci/plugins/plaincredentials/impl/FileCredentialsImpl.java)

```yaml
credentials
  my-secret-file:
    type: file
    fileName: my-secret-file
    secretBytes: VGhpcyBpcyBhIHBsYWluIGNvbnRlbnQK # -> 'This is a plain content' | base64
```
