### PR TITLE
Adding support creating jobs within subfolders

### DIFF
--- a/config-handlers/SeedJobsConfig.groovy
+++ b/config-handlers/SeedJobsConfig.groovy
@@ -7,6 +7,9 @@ def asBoolean(value, defaultValue=false){
 
 def getOrCreateFolder(def parent, def name) {
     def folder
+    if (name == "") {
+        return null
+    }
     if (parent == null) {
         parent = jenkins.model.Jenkins.instance
         folder = jenkins.model.Jenkins.instance.getItem(name)

--- a/config-handlers/SeedJobsConfig.groovy
+++ b/config-handlers/SeedJobsConfig.groovy
@@ -8,9 +8,10 @@ def asBoolean(value, defaultValue=false){
 def getOrCreateFolder(def parent, def name) {
     def folder
     if (parent == null) {
+        parent = jenkins.model.Jenkins.instance
         folder = jenkins.model.Jenkins.instance.getItem(name)
     } else {
-        folder = parent.getItem(name)
+        folder = jenkins.model.Jenkins.instance.getItemByFullName("${parent.getName()}/${name}")
     }
 
     if (folder != null) {
@@ -20,7 +21,7 @@ def getOrCreateFolder(def parent, def name) {
             throw new Exception("${folder} already exists, but it's not a folder")
         }
     }
-    return jenkins.model.Jenkins.instance.createProject(com.cloudbees.hudson.plugins.folder.Folder, name)
+    return parent.createProject(com.cloudbees.hudson.plugins.folder.Folder, name)
 }
 
 

--- a/tests/groovy/config-handlers/SeedJobsConfigTest.groovy
+++ b/tests/groovy/config-handlers/SeedJobsConfigTest.groovy
@@ -118,7 +118,7 @@ SIMPLE_TEXT_LINE2
     def jobInsideFolder = jenkins.model.Jenkins.instance.getItemByFullName('/myfolder/my-seed-job-inside-folder')
     assert jobInsideFolder instanceof org.jenkinsci.plugins.workflow.job.WorkflowJob
 
-    def jobInsideSubFolder = jenkins.model.Jenkins.instance.getItemByFullName('/myfolder/mysubfolder/my-seed-job-inside-folder')
+    def jobInsideSubFolder = jenkins.model.Jenkins.instance.getItemByFullName('/myfolder/mysubfolder/my-seed-job-inside-subfolder')
     assert jobInsideSubFolder instanceof org.jenkinsci.plugins.workflow.job.WorkflowJob
 
 }

--- a/tests/groovy/config-handlers/SeedJobsConfigTest.groovy
+++ b/tests/groovy/config-handlers/SeedJobsConfigTest.groovy
@@ -67,6 +67,12 @@ my-seed-job:
     branch: my-test-branch
     credentialsId: my-git-key
   pipeline: src/groovy/Jenkinsfile-config
+/myfolder/mysubfolder/my-seed-job-inside-subfolder:
+  source:
+    remote: git@github.com:odavid/my-bloody-jenkins.git
+    branch: my-test-branch
+    credentialsId: my-git-key
+  pipeline: src/groovy/Jenkinsfile-config
 
 """)
     configHandler.setup(config)
@@ -111,6 +117,9 @@ SIMPLE_TEXT_LINE2
 
     def jobInsideFolder = jenkins.model.Jenkins.instance.getItemByFullName('/myfolder/my-seed-job-inside-folder')
     assert jobInsideFolder instanceof org.jenkinsci.plugins.workflow.job.WorkflowJob
+
+    def jobInsideSubFolder = jenkins.model.Jenkins.instance.getItemByFullName('/myfolder/mysubfolder/my-seed-job-inside-folder')
+    assert jobInsideSubFolder instanceof org.jenkinsci.plugins.workflow.job.WorkflowJob
 
 }
 


### PR DESCRIPTION
Adding support to create jobs within subfolders.
Example:
"TestDir1/TestDir2/TestJob"

Currently such job ^ converted to "TestDir1/TestJob"