### PR TITLE
Allow FSSCM for shared libraries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-examples
-*/.data/*

--- a/config-handlers/PipelineLibrariesConfig.groovy
+++ b/config-handlers/PipelineLibrariesConfig.groovy
@@ -1,4 +1,5 @@
 import org.jenkinsci.plugins.structs.describable.DescribableModel
+import org.jenkinsci.plugins.workflow.libs.*
 import jenkins.model.Jenkins
 
 def asInt(value, defaultValue=0){

--- a/config-handlers/PipelineLibrariesConfig.groovy
+++ b/config-handlers/PipelineLibrariesConfig.groovy
@@ -62,9 +62,10 @@ def libraryConfig(config){
             scm = tryCreateDynamicSCMSource(name, scmConfig)
         }
         if(scm){
+            //support of legacySCM
+            def scmSource = scm instanceof hudson.scm.SCM ? new SCMRetriever(scm) : new SCMSourceRetriever(scm)
             def libraryConfiguration = new org.jenkinsci.plugins.workflow.libs.LibraryConfiguration(
-                name,
-                new org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever(scm)
+                    name, scmSource
             )
             libraryConfiguration.defaultVersion = defaultVersion
             libraryConfiguration.implicit = asBoolean(implicit)

--- a/plugins.txt
+++ b/plugins.txt
@@ -70,6 +70,7 @@ extended-choice-parameter:0.78
 extensible-choice-parameter:1.6.0
 external-monitor-job:1.7
 favorite:2.3.2
+filesystem_scm:2.0
 gatling:1.2.7
 git-changelog:2.21
 git-client:3.0.0

--- a/tests/groovy/config-handlers/PipelineLibrariesConfigTest.groovy
+++ b/tests/groovy/config-handlers/PipelineLibrariesConfigTest.groovy
@@ -22,15 +22,15 @@ my-lib-with-defaults:
     remote: git@github.com:odavid/my-bloody-jenkins.git
     credentialsId: my-git-key
 my-fsscm-lib:
+  defaultVersion: default    
+  implicit: true
   retriever:
     scm:
       \$class: hudson.plugins.filesystem_scm.FSSCM
       path: "//zzz/aaa"
       clearWorkspace: true
       copyHidden: false
-      filterSettings: null
-  defaultVersion: default    
-  implicit: true  
+      filterSettings: null    
 dynamic-scm-source:
   defaultVersion: p4-version
   implicit: true
@@ -80,7 +80,7 @@ dynamic-scm-source:
     assert (myLib.retriever.scm instanceof hudson.scm.SCM)
     assert myLib.retriever.scm.clearWorkspace
     assert myLib.retriever.scm.copyHidden == false
-    assert myLib.retriever.scm.path == '//xxx/yyy'
+    assert myLib.retriever.scm.path == '//zzz/aaa'
 }
 
 testLibraries()

--- a/tests/groovy/config-handlers/PipelineLibrariesConfigTest.groovy
+++ b/tests/groovy/config-handlers/PipelineLibrariesConfigTest.groovy
@@ -28,7 +28,8 @@ my-fsscm-lib:
         path: "//zzz/aaa"
         clearWorkspace: true
         copyHidden: false
-        filterSettings: null    
+        filterSettings: null
+    defaultVersion: default    
     implicit: true  
 dynamic-scm-source:
   defaultVersion: p4-version
@@ -74,7 +75,7 @@ dynamic-scm-source:
     assert myLib.retriever.scm.path == '//xxx/yyy'
 
     myLib = org.jenkinsci.plugins.workflow.libs.GlobalLibraries.get().libraries.find{ it.name == 'my-fsscm-lib'}
-    assert myLib.defaultVersion == ''
+    assert myLib.defaultVersion == 'default'
     assert myLib.implicit
     assert (myLib.retriever.scm instanceof hudson.scm.SCM)
     assert myLib.retriever.scm.clearWorkspace

--- a/tests/groovy/config-handlers/PipelineLibrariesConfigTest.groovy
+++ b/tests/groovy/config-handlers/PipelineLibrariesConfigTest.groovy
@@ -21,6 +21,15 @@ my-lib-with-defaults:
   source:
     remote: git@github.com:odavid/my-bloody-jenkins.git
     credentialsId: my-git-key
+my-fsscm-lib:
+  retriever:
+      scm:
+        \$class: hudson.plugins.filesystem_scm.FSSCM
+        path: "//zzz/aaa"
+        clearWorkspace: true
+        copyHidden: false
+        filterSettings: null    
+    implicit: true  
 dynamic-scm-source:
   defaultVersion: p4-version
   implicit: true
@@ -62,6 +71,14 @@ dynamic-scm-source:
     assert myLib.implicit
     assert (myLib.retriever.scm instanceof org.jenkinsci.plugins.p4.scm.GlobalLibraryScmSource)
     assert myLib.retriever.scm.credential == 'p4-creds'
+    assert myLib.retriever.scm.path == '//xxx/yyy'
+
+    myLib = org.jenkinsci.plugins.workflow.libs.GlobalLibraries.get().libraries.find{ it.name == 'my-fsscm-lib'}
+    assert myLib.defaultVersion == ''
+    assert myLib.implicit
+    assert (myLib.retriever.scm instanceof hudson.scm.SCM)
+    assert myLib.retriever.scm.clearWorkspace
+    assert myLib.retriever.scm.copyHidden == false
     assert myLib.retriever.scm.path == '//xxx/yyy'
 }
 

--- a/tests/groovy/config-handlers/PipelineLibrariesConfigTest.groovy
+++ b/tests/groovy/config-handlers/PipelineLibrariesConfigTest.groovy
@@ -23,14 +23,14 @@ my-lib-with-defaults:
     credentialsId: my-git-key
 my-fsscm-lib:
   retriever:
-      scm:
-        \$class: hudson.plugins.filesystem_scm.FSSCM
-        path: "//zzz/aaa"
-        clearWorkspace: true
-        copyHidden: false
-        filterSettings: null
-    defaultVersion: default    
-    implicit: true  
+    scm:
+      \$class: hudson.plugins.filesystem_scm.FSSCM
+      path: "//zzz/aaa"
+      clearWorkspace: true
+      copyHidden: false
+      filterSettings: null
+  defaultVersion: default    
+  implicit: true  
 dynamic-scm-source:
   defaultVersion: p4-version
   implicit: true


### PR DESCRIPTION
Added support of using FSSCM plugin (https://github.com/jenkinsci/filesystem_scm-plugin) for shared libraries.