### PR TITLE
Fix S3 handler in fetchconfig.py

### DIFF
--- a/bin/fetchconfig.py
+++ b/bin/fetchconfig.py
@@ -8,11 +8,8 @@ import glob
 import os
 import requests
 import yaml
+import io
 from shutil import copyfile
-try:
-    from StringIO import StringIO ## for Python 2
-except ImportError:
-    from io import StringIO ## for Python 3
 
 def merge_dict(source, target):
     source = source.copy()
@@ -42,7 +39,7 @@ def fetch_s3(source):
     bucket_name = source.split('/')[0]
     s3_key = '/'.join(source.split('/')[1:])
     try:
-        outbuff = StringIO.StringIO()
+        outbuff = io.BytesIO()
         s3.Bucket(bucket_name).download_fileobj(s3_key, outbuff)
         data = outbuff.getvalue()
         configs.append(dict(src=source, contents=data))


### PR DESCRIPTION
Errors occurred while we trying to update from 2.190.3-168 to 2.204.2-177:
```
2020-02-12 16:23:23 - /usr/bin/watch-config.sh started
2020-02-12 16:23:23 - URL = s3://jenkins/config.yaml
2020-02-12 16:23:23 - URL_TYPE =
2020-02-12 16:23:23 - CACHE_DIR = /dev/shm/.jenkins-config-cache
2020-02-12 16:23:23 - POLLING_INTERVAL = 15
2020-02-12 16:23:23 - FILENAME = /dev/shm/jenkins-config.yml
2020-02-12 16:23:23 - COMMAND = update-config.sh
2020-02-12 16:23:23 - SKIP_WATCH =
2020-02-12 16:23:23 - DEBUG =
2020-02-12 16:23:23 - Fetching /dev/shm/jenkins-config.yml for the first time...
Traceback (most recent call last):
  File "/usr/bin/fetchconfig.py", line 126, in <module>
    main()
  File "/usr/bin/fetchconfig.py", line 112, in main
    config = fetch_merged_config(args.source)
  File "/usr/bin/fetchconfig.py", line 90, in fetch_merged_config
    raw_configs += fetch_s3(src)
  File "/usr/bin/fetchconfig.py", line 45, in fetch_s3
    outbuff = StringIO.StringIO()
AttributeError: type object '_io.StringIO' has no attribute 'StringIO'
```

I corrected the script `/usr/bin/fetchconfig.py` for the correct use of the module `io` in python 3.