### PR TITLE
Support for user accounts in jenkins_database realm

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ Responsible for:
 security:
     realm: jenkins_database
     adminPassword: S3cr3t
+    # When using jenkins_database, you can also create user accounts from YAML configuration
+    users:
+      - id: user1
+        password: passwordOf-user#1
+      - id: user2
+        password: other-password#2
 ```
 
 ```yaml

--- a/config-handlers/SecurityConfig.groovy
+++ b/config-handlers/SecurityConfig.groovy
@@ -84,6 +84,9 @@ def setupJenkinsDatabase(config){
     def securityRealm = (currnetRealm instanceof HudsonPrivateSecurityRealm) ? currnetRealm : new HudsonPrivateSecurityRealm(false)
     config.with{
         securityRealm.createAccount(adminUser, adminPassword)
+        users?.each{ user ->
+            securityRealm.createAccount(user.id, user.password)
+        }
     }
     return securityRealm
 }

--- a/tests/groovy/config-handlers/SecurityConfigTest.groovy
+++ b/tests/groovy/config-handlers/SecurityConfigTest.groovy
@@ -192,6 +192,20 @@ adminPassword: admin
  }
 
 
+ def testJenkinsDatabaseUsers(){
+    def config = new Yaml().load("""
+adminUser: admin
+adminPassword: admin
+users:
+  - id: user1
+    password: user1pass
+"""
+    )
+    def realm = configHandler.setupJenkinsDatabase(config)
+    assert (realm instanceof hudson.security.HudsonPrivateSecurityRealm)
+    assert hudson.model.User.get('user1', false) != null
+ }
+
 def testPlainTextMarkupFormatter(){
     def config = new Yaml().load("""
 markupFormatter: plainText
@@ -240,6 +254,7 @@ testActiveDirectory()
 testAuthorizationStrategy()
 testSecurityOptions()
 testJenkinsDatabase()
+testJenkinsDatabaseUsers()
 testPlainTextMarkupFormatter()
 testSafeHtmlMarkupFormatter()
 testRawHtmlMarkupFormatter()


### PR DESCRIPTION
```yaml
security:
    realm: jenkins_database
    adminPassword: S3cr3t
    users:
      - id: user1
        password: password1
```