### PR TITLE
Fix to reload configuration on config.yaml change

### DIFF
--- a/bin/update-config.sh
+++ b/bin/update-config.sh
@@ -1,21 +1,28 @@
 #!/bin/bash -e
+#NOTE: to work with CSRF enabled it requires: '-Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true', ie ENV: JAVA_OPTS_LONGLIVING_CRUMB: '-Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true'
 
 script_dir=$(cd $(dirname "$0"); pwd)
 token_file="$TOKEN_FILE_LOCATION"
+external_jenkins_admin_creds="$EXTERNAL_JENKINS_ADMIN_CREDENTIALS"
 
 AUTH_ARG=""
 
-if [ -f $token_file ]; then
-    AUTH_ARG="-auth $(cat $token_file)"
-fi
+if [ -z "$external_jenkins_admin_creds" ]; then
+    if [ -f $token_file ]; then
+        AUTH_ARG="$(cat $token_file)"
+    fi
+else
+    AUTH_ARG=$external_jenkins_admin_creds
+fi 
 
-if [ ! -f $script_dir/jenkins-cli.jar ]; then
-    curl -o $script_dir/jenkins-cli.jar http://localhost:8080/jnlpJars/jenkins-cli.jar
-fi
+is_csrf_enabled=$(curl --user $AUTH_ARG -s http://localhost:8080/api/json 2> /dev/null | python -c 'import sys,json;exec "try:\n  j=json.load(sys.stdin)\n  print str(j[\"useCrumbs\"]).lower()\nexcept:\n  pass"')
 
+token_data=""
+if [ $is_csrf_enabled == "true" ]; then
+    mytoken=$(curl --user $AUTH_ARG -s http://localhost:8080/crumbIssuer/api/json | python -c 'import sys,json;j=json.load(sys.stdin);print j["crumbRequestField"] + "=" + j["crumb"]')
+    token_data="-d "$mytoken""
+fi
 
 echo "Updating Jenkins Configuration"
-java -jar $script_dir/jenkins-cli.jar \
-    -s http://localhost:8080/ $AUTH_ARG \
-    groovy = < /var/jenkins_home/init.groovy.d/JenkinsConfigLoader.groovy
+curl --user $AUTH_ARG $token_data --data-urlencode "script=$(< /var/jenkins_home/init.groovy.d/JenkinsConfigLoader.groovy)" http://localhost:8080/scriptText
 echo "Jenkins Configuration Updated"


### PR DESCRIPTION
Following changes are:
- fixing automatic configuration reload on config.yaml change
- adding (limited) CSRF support 
- allowing authorization of administrator authenticated through external server, in example Active Directory.

Reload was not working because of jenkins-cli - Jenkins 2.165 and newer no longer supports the old (-remoting) mode in either the client or server.

In order to make curl work, script needs to support CSRF which is enabled by default.
I found no way to bring full CSRF support - "CSRF tokens (crumbs) are now only valid for the web session they were created", instead I am telling Jenkins to validate also "older" tokens with the use of following flag:  '-Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true', ie ENV: JAVA_OPTS_LONGLIVING_CRUMB: '-Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true'
