### PR TITLE
Adds ability to disable Matrix-based Authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Responsible for:
     * google - Uses [google-login plugin](https://plugins.jenkins.io/google-login)
     * oic - Uses [oic-auth plugin](https://plugins.jenkins.io/oic-auth/)
 * User/Group Permissions dict - Each key represent a user or a group and its value is a list of Jenkins [Permissions IDs](https://wiki.jenkins.io/display/JENKINS/Matrix-based+security)
-    * For disable configure Matrix based Security you should add "projectMatrixAuthorizationStrategy: false" (Anyone can do anything)
+    * For disable configure Matrix based Security you should add "unsecureStrategy: true" (Anyone can do anything)
 
 ```yaml
 # jenkins_database - adminPassword must be provided

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Responsible for:
     * google - Uses [google-login plugin](https://plugins.jenkins.io/google-login)
     * oic - Uses [oic-auth plugin](https://plugins.jenkins.io/oic-auth/)
 * User/Group Permissions dict - Each key represent a user or a group and its value is a list of Jenkins [Permissions IDs](https://wiki.jenkins.io/display/JENKINS/Matrix-based+security)
+    * For disable configure Matrix based Security you should add "projectMatrixAuthorizationStrategy: false" (Anyone can do anything)
 
 ```yaml
 # jenkins_database - adminPassword must be provided

--- a/config-handlers/SecurityConfig.groovy
+++ b/config-handlers/SecurityConfig.groovy
@@ -106,7 +106,7 @@ def setupGoogleOAuth2(config){
 
 def createAuthorizationStrategy(config, adminUser){
     def strategy = new hudson.security.AuthorizationStrategy.Unsecured()
-    if (asBoolean(config['projectMatrixAuthorizationStrategy'], true)){
+    if (!asBoolean(config['unsecureStrategy'], false)){
         strategy = new ProjectMatrixAuthorizationStrategy()
         strategy.add(Hudson.ADMINISTER, adminUser)
         config?.permissions?.each{ principal, permissions ->
@@ -210,7 +210,7 @@ def setup(config){
     if(realm){
         instance.setSecurityRealm(realm)
         def strategy = createAuthorizationStrategy(config, adminUser)
-        if (!strategy instanceof hudson.security.AuthorizationStrategy$Unsecured){
+        if (strategy instanceof hudson.security.ProjectMatrixAuthorizationStrategy){
             instance.setAuthorizationStrategy(strategy)
         }
         instance.save()

--- a/config-handlers/SecurityConfig.groovy
+++ b/config-handlers/SecurityConfig.groovy
@@ -5,6 +5,7 @@ import hudson.security.HudsonPrivateSecurityRealm
 import jenkins.security.plugins.ldap.FromGroupSearchLDAPGroupMembershipStrategy
 import jenkins.security.plugins.ldap.FromUserRecordLDAPGroupMembershipStrategy
 import org.jenkinsci.plugins.oic.OicSecurityRealm
+import hudson.security.AuthorizationStrategy
 import jenkins.model.Jenkins
 import hudson.model.Hudson
 import hudson.model.Item
@@ -104,16 +105,19 @@ def setupGoogleOAuth2(config){
 
 
 def createAuthorizationStrategy(config, adminUser){
-    def strategy = new ProjectMatrixAuthorizationStrategy()
-    strategy.add(Hudson.ADMINISTER, adminUser)
-    config?.permissions?.each{ principal, permissions ->
-        for(p in permissions){
-            try{
-                def permission = hudson.security.Permission.fromId(p)
-                strategy.add(permission, principal)
-            }catch(e){
-                println "Failed to set permission ${p} for principal ${principal}... ${e}"
-                e.printStackTrace()
+    def strategy = new hudson.security.AuthorizationStrategy.Unsecured()
+    if (asBoolean(config['projectMatrixAuthorizationStrategy'], true)){
+        strategy = new ProjectMatrixAuthorizationStrategy()
+        strategy.add(Hudson.ADMINISTER, adminUser)
+        config?.permissions?.each{ principal, permissions ->
+            for(p in permissions){
+                try{
+                    def permission = hudson.security.Permission.fromId(p)
+                    strategy.add(permission, principal)
+                }catch(e){
+                    println "Failed to set permission ${p} for principal ${principal}... ${e}"
+                    e.printStackTrace()
+                }
             }
         }
     }
@@ -206,7 +210,9 @@ def setup(config){
     if(realm){
         instance.setSecurityRealm(realm)
         def strategy = createAuthorizationStrategy(config, adminUser)
-        instance.setAuthorizationStrategy(strategy)
+        if (!strategy instanceof hudson.security.AuthorizationStrategy$Unsecured){
+            instance.setAuthorizationStrategy(strategy)
+        }
         instance.save()
     }
 }

--- a/tests/groovy/config-handlers/SecurityConfigTest.groovy
+++ b/tests/groovy/config-handlers/SecurityConfigTest.groovy
@@ -203,7 +203,7 @@ permissions:
 
 def testUnsecureAuthorizationStrategy(){
 	def config = new Yaml().load("""
-projectMatrixAuthorizationStrategy: false
+unsecureStrategy: true
 """
     )
     def strategy = configHandler.createAuthorizationStrategy(config, 'admin')

--- a/tests/groovy/config-handlers/SecurityConfigTest.groovy
+++ b/tests/groovy/config-handlers/SecurityConfigTest.groovy
@@ -199,7 +199,16 @@ permissions:
     assert grantedPermissions[hudson.security.Permission.fromId('hudson.model.Item.Discover')] == (['authenticated'] as Set)
     assert grantedPermissions[hudson.security.Permission.fromId('hudson.model.Item.Cancel')] == (['authenticated'] as Set)
     assert grantedPermissions[hudson.security.Permission.fromId('hudson.model.Hudson.Administer')] == (['admin'] as Set)
- }
+}
+
+def testUnsecureAuthorizationStrategy(){
+	def config = new Yaml().load("""
+projectMatrixAuthorizationStrategy: false
+"""
+    )
+    def strategy = configHandler.createAuthorizationStrategy(config, 'admin')
+    assert strategy instanceof hudson.security.AuthorizationStrategy$Unsecured
+}
 
 def testSecurityOptions(){
     def config = new Yaml().load("""
@@ -299,6 +308,7 @@ testLdap()
 testOIC()
 testActiveDirectory()
 testAuthorizationStrategy()
+testUnsecureAuthorizationStrategy()
 testSecurityOptions()
 testJenkinsDatabase()
 testJenkinsDatabaseUsers()


### PR DESCRIPTION
To enable "folder-auth" plugin we should have the ability to disable Matrix-based Authorization, because ConfigurationAsCode handler runs before Security handler.