### PR TITLE
Fix for repeated deprecation warning raised in fetchconfig.py.

### DIFF
--- a/bin/fetchconfig.py
+++ b/bin/fetchconfig.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import print_function
 import argparse
-import collections
 import boto3
 import botocore
 import glob
@@ -11,11 +10,16 @@ import yaml
 import io
 from shutil import copyfile
 
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
 def merge_dict(source, target):
     source = source.copy()
     for k, v in target.items():
-        if (k in source and isinstance(source[k], collections.Mapping)
-                and isinstance(target[k], collections.Mapping)):
+        if (k in source and isinstance(source[k], Mapping)
+                and isinstance(target[k], Mapping)):
             source[k] = merge_dict(source[k], target[k])
         else:
             source[k] = target[k]
@@ -93,7 +97,7 @@ def fetch_merged_config(source):
         c = yaml.safe_load(rc['contents'])
         if c is None:
             continue
-        elif not isinstance(c, collections.Mapping):
+        elif not isinstance(c, Mapping):
             raise ValueError("Invalid Yaml content: %s" % rc['src'])
         config = merge_dict(config, c)
     return config


### PR DESCRIPTION
The following warning is raised repeatedly by fetchconfig.py:
```
   elif not isinstance(c, collections.Mapping):
 /usr/bin/fetchconfig.py:96: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
```
This PR includes a fix for this repeated warning.