### PR TITLE
Initial support of Github-OAuth autorization strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Responsible for:
     * saml - Uses [saml plugin](https://plugins.jenkins.io/saml)
     * google - Uses [google-login plugin](https://plugins.jenkins.io/google-login)
     * oic - Uses [oic-auth plugin](https://plugins.jenkins.io/oic-auth/)
+    * github - Uses [github-oauth plugin](https://plugins.jenkins.io/github-oauth)
 * User/Group Permissions dict - Each key represent a user or a group and its value is a list of Jenkins [Permissions IDs](https://wiki.jenkins.io/display/JENKINS/Matrix-based+security)
     * For disable configure Matrix based Security you should add "unsecureStrategy: true" (Anyone can do anything)
 
@@ -375,6 +376,18 @@ security:
     escapeHatchUsername: admin
     escapeHatchSecret: password
     escapeHatchGroup:
+```
+
+```yaml
+# github - github-oauth configuration must be provided
+security:
+  realm: github
+  realmConfig:
+    githubWebUri: https://github.com
+    githubApiUri: https://api.github.com
+    clientID: client-id
+    clientSecret: client-secret
+    oauthScopes: read:org
 ```
 
 ```yaml

--- a/config-handlers/SecurityConfig.groovy
+++ b/config-handlers/SecurityConfig.groovy
@@ -180,6 +180,11 @@ def setupOpenIDConnect(config){
     return realmConfig ? DescribableModel.of(org.jenkinsci.plugins.oic.OicSecurityRealm).instantiate(realmConfig) : null
 }
 
+def setupGithubOAuth2(config){
+    def realmConfig = config.realmConfig
+    return realmConfig ? DescribableModel.of(org.jenkinsci.plugins.GithubSecurityRealm).instantiate(realmConfig) : null
+}
+
 def setup(config){
     config = config ?: [:]
     setupSecurityOptions(config.securityOptions)
@@ -205,6 +210,9 @@ def setup(config){
             break
         case 'oic':
             realm = setupOpenIDConnect(config)
+            break
+        case 'github':
+            realm = setupGithubOAuth2(config)
             break
     }
     if(realm){

--- a/plugins.txt
+++ b/plugins.txt
@@ -183,3 +183,4 @@ workflow-step-api:2.23
 workflow-support:3.8
 ws-cleanup:0.39
 xvfb:1.1.3
+github-oauth:0.33

--- a/tests/groovy/config-handlers/SecurityConfigTest.groovy
+++ b/tests/groovy/config-handlers/SecurityConfigTest.groovy
@@ -179,6 +179,24 @@ jenkinsInternalUser: admin
     assert realm.internalUsersDatabase.jenkinsInternalUser == 'admin'
 }
 
+def testGithubLogin(){
+  def config = new Yaml().load("""
+realmConfig:
+  githubWebUri: https://github.com
+  githubApiUri: https://api.github.com
+  clientID: client-id
+  clientSecret: client-secret
+  oauthScopes: read:org
+""")
+    def githubOAuth2Realm = configHandler.setupGithubOAuth2(config)
+    assert githubOAuth2Realm instanceof org.jenkinsci.plugins.GithubSecurityRealm
+    assert githubOAuth2Realm.githubWebUri == "https://github.com"
+    assert githubOAuth2Realm.githubApiUri == "https://api.github.com"
+    assert githubOAuth2Realm.clientID == "client-id"
+    assert githubOAuth2Realm.clientSecret.toString() == "client-secret"
+    assert githubOAuth2Realm.oauthScopes.toString() == "read:org"
+}
+
 def testAuthorizationStrategy(){
 	def config = new Yaml().load("""
 permissions:
@@ -307,6 +325,7 @@ testSaml()
 testLdap()
 testOIC()
 testActiveDirectory()
+testGithubLogin()
 testAuthorizationStrategy()
 testUnsecureAuthorizationStrategy()
 testSecurityOptions()


### PR DESCRIPTION
Tracking issue: https://github.com/odavid/my-bloody-jenkins/issues/184

Tests Alpine:
```
bats tests
 ✓ >>> setup config deep-merge with multiple data sources env
 ✓ test values comming from dir1
 ✓ test values comming from dir1 and dir2
 ✓ test values comming from dir1 and dir2 and dir3-1 (glob expression)
 ✓ test values comming from dir1 and dir2 and dir3-2 (glob expression)
 ✓ <<< teardown config deep-merge with multiple data sources env
 ✓ >>> setup config-envvars env
 ✓ test values comming from secret1
 ✓ test values comming from secret2
 ✓ test values changed
 ✓ <<< teardown config-envvars env
 ✓ >>> setup config-handlers tests env
 ✓ Sanity
 ✓ ConfigurationAsCodeConfig
 ✓ RemoveMasterEnvVarsConfig
 ✓ ArtifactoryConfig
 ✓ CloudsConfig
 ✓ CredsConfig
 ✓ ToolsConfig
 ✓ SecurityConfig
 ✓ CheckmarxConfig
 ✓ EnvironmentVarsConfig
 ✓ GitlabConfig
 ✓ JiraConfig
 ✓ JiraStepsConfig
 ✓ NotifiersConfig
 ✓ PipelineLibrariesConfig
 ✓ ScriptApprovalConfig
 ✓ SeedJobsConfig
 ✓ JobDSLScriptsConfig
 ✓ SonarQubeServersConfig
 ✓ <<< teardown config-handlers tests env
 ✓ >>> setup envconsul tests env
 ✓ test values comming from consul
 ✓ test values comming from vault
 ✓ <<< teardown envconsul tests env

36 tests, 0 failures
```

Signed-off-by: Illia P <illia.pshonkin@percona.com>